### PR TITLE
Merge branch 'feature/getTokenTransfers' into branch 'main'.

### DIFF
--- a/src/ankr.js
+++ b/src/ankr.js
@@ -294,15 +294,21 @@ class Ankr extends BaseServer {
       pageToken = r.nextPageToken
     } while (pageToken)
 
-    const transfers = logs.map(log => {
-      return {
+    const transfers = []
+
+    for (const log of logs) {
+      const tx = await this.web3.eth.getTransaction(log.transactionHash)
+
+      transfers.push({
         txid: log.transactionHash,
         height: log.blockNumber,
         from: log.event.inputs[0].valueDecoded.toLowerCase(),
         to: log.event.inputs[1].valueDecoded.toLowerCase(),
+        gas: Number(tx.gas),
+        gasPrice: Number(tx.gasPrice),
         value: Number.parseInt(log.event.inputs[2].valueDecoded)
-      }
-    })
+      })
+    }
 
     reply.send(this._result(id, transfers))
   }

--- a/src/hardhat.js
+++ b/src/hardhat.js
@@ -256,17 +256,23 @@ class Hardhat extends BaseServer {
       toBlock: toBlock || await eth.getBlockNumber()
     })
 
-    const events = rawEvents.map((e) => {
-      return {
-        txid: e.transactionHash,
-        height: e.blockNumber.toString(),
-        from: e.returnValues._from.toLowerCase(),
-        to: e.returnValues._to.toLowerCase(),
-        value: e.returnValues._value.toString()
-      }
-    })
+    const transfers = []
 
-    reply.send(this._result(id, events))
+    for (const event of rawEvents) {
+      const tx = await this.web3.eth.getTransaction(event.transactionHash)
+
+      transfers.push({
+        txid: event.transactionHash,
+        height: event.blockNumber.toString(),
+        from: event.returnValues._from.toLowerCase(),
+        to: event.returnValues._to.toLowerCase(),
+        gas: Number(tx.gas),
+        gasPrice: Number(tx.gasPrice),
+        value: event.returnValues._value.toString()
+      })
+    }
+    
+    reply.send(this._result(id, transfers))
   }
 
   /**


### PR DESCRIPTION
The event logs don't contain the 'gas' and 'gasPrice' properties, so i added a call to the provider's 'getTransaction' method for each log to retrieve the tx's detail (which includes those values). This slows down the endpoint a bit, especially for large block ranges with many token transfers.

However, I don't think this will affect the application much. 'syncTransactions' always run on a range of blocks, which is [startSyncTxFromBlock, "latest"] ('startSyncTxFromBlock' is updated after each call); only the first request will cover a large amount of blocks, making subsequent requests much faster.

If you have a better idea, let's discuss it here.